### PR TITLE
Add basic UdonBehaviour symbol editing to UdonMonitor

### DIFF
--- a/Packages/com.varneon.vudon.udonity/Editor/UdonProgramDataStorageGenerator.cs
+++ b/Packages/com.varneon.vudon.udonity/Editor/UdonProgramDataStorageGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using UdonSharp;
 using UnityEditor;
@@ -41,7 +42,7 @@ namespace Varneon.VUdon.UdonProgramDataStorage
 
                 IUdonSymbolTable symbolTable = program.SymbolTable;
 
-                System.Collections.Immutable.ImmutableArray<string> symbols = symbolTable.GetSymbols();
+                ImmutableArray<string> symbols = symbolTable.GetSymbols();
 
                 IUdonHeap heap = program.Heap;
 
@@ -63,7 +64,7 @@ namespace Varneon.VUdon.UdonProgramDataStorage
 
                 programInfos.Add(header);
 
-                IEnumerable<string> filteredSymbols = symbols;//.Where(s => !s.StartsWith("__"));
+                IEnumerable<string> filteredSymbols = symbols.Sort();//.Where(s => !s.StartsWith("__"));
 
                 programSymbols.Add(filteredSymbols.ToArray());
 
@@ -71,7 +72,7 @@ namespace Varneon.VUdon.UdonProgramDataStorage
 
                 IUdonSymbolTable entryPointTable = program.EntryPoints;
 
-                IEnumerable<string> filteredEntryPoints = entryPointTable.GetSymbols().Where(s => !s.StartsWith("_onVarChange_"));
+                IEnumerable<string> filteredEntryPoints = entryPointTable.GetSymbols().Where(s => !s.StartsWith("_onVarChange_")).ToImmutableSortedSet();
 
                 programEntryPoints.Add(filteredEntryPoints.ToArray());
 

--- a/Packages/com.varneon.vudon.udonity/Editor/UdonityBuildPostProcessor.cs
+++ b/Packages/com.varneon.vudon.udonity/Editor/UdonityBuildPostProcessor.cs
@@ -408,6 +408,10 @@ namespace Varneon.VUdon.Udonity.Editor
 
             if(udonMonitorWindow == null) { return; }
 
+            udonMonitorWindow.InitializeOnBuild();
+
+            udonMonitorWindow.udonity = udonity;
+
             udonMonitorWindow.programDataStorage = editorRoot.GetComponentInChildren<UdonProgramDataStorage>(true);
         }
 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/Editor/UdonityEditor.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/Editor/UdonityEditor.prefab
@@ -13389,7 +13389,13 @@ MonoBehaviour:
     type: 3}
   meshColliderVisualizerPrefab: {fileID: 5571147441174118855, guid: d2131877fead73c4f89145ed79b561d2,
     type: 3}
+  toggleFieldPrefab: {fileID: 6550217052911721319, guid: d60e45b0919e4ff419b7be7258c9ec16,
+    type: 3}
+  textFieldPrefab: {fileID: 7733530533115775474, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+    type: 3}
   colorFieldPrefab: {fileID: 1195879520915560244, guid: 64b057eeeb8e43949a204a40f2a7240b,
+    type: 3}
+  vector2FieldPrefab: {fileID: 4665160837381826593, guid: a671a3647c610c3439efbeaa1c742a46,
     type: 3}
   vector3FieldPrefab: {fileID: 1383401300499385296, guid: 3fd2bd80b663d7a41aa8459b9abc13b4,
     type: 3}
@@ -17288,7 +17294,7 @@ GameObject:
   - component: {fileID: 2085449327916956164}
   - component: {fileID: 8821671612200382920}
   m_Layer: 0
-  m_Name: TOOLBAR (1)
+  m_Name: TOOLBAR_SYMBOL_LIST
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -18349,6 +18355,80 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   iconName: d_RotateTool@2x
+--- !u!1 &1751876561838024704
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2971927798548322818}
+  - component: {fileID: 6732797128992649428}
+  - component: {fileID: 8665161901507368726}
+  m_Layer: 0
+  m_Name: BORDER_BOTTOM
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2971927798548322818
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1751876561838024704}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7499305319063945412}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0.5}
+  m_SizeDelta: {x: 0, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6732797128992649428
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1751876561838024704}
+  m_CullTransparentMesh: 0
+--- !u!114 &8665161901507368726
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1751876561838024704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.15686275, g: 0.15686275, b: 0.15686275, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &1753622547996723011
 GameObject:
   m_ObjectHideFlags: 0
@@ -24686,13 +24766,17 @@ MonoBehaviour:
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 2344236196220650554}
   programDataStorage: {fileID: 0}
+  udonity: {fileID: 0}
   headerInfoText: {fileID: 1732559752279711441}
   symbolContainer: {fileID: 2090323913146029743}
+  symbolFieldContainer: {fileID: 4709041438451282953}
   entryPointContainer: {fileID: 5333563462114283677}
   symbolListItem: {fileID: 6004917945910750663, guid: 9aeaf74a9e2d7804f8a33a6b289b08dd,
     type: 3}
   entryPointListItem: {fileID: 7529181235983169324, guid: 802af46f7abfb4c4eb8baf3aaa05e878,
     type: 3}
+  symbolNameField: {fileID: 8371800499309815806}
+  symbolTypeField: {fileID: 7526199440941272431}
   logger: {fileID: 5406568143624742404}
 --- !u!114 &2344236196220650554
 MonoBehaviour:
@@ -27363,6 +27447,80 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2556919426089710792
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3315783714719116490}
+  - component: {fileID: 4639161998043273394}
+  - component: {fileID: 750876654750463533}
+  m_Layer: 0
+  m_Name: BORDER_TOP
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3315783714719116490
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2556919426089710792}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7499305319063945412}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.5}
+  m_SizeDelta: {x: 0, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4639161998043273394
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2556919426089710792}
+  m_CullTransparentMesh: 0
+--- !u!114 &750876654750463533
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2556919426089710792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.15686275, g: 0.15686275, b: 0.15686275, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2558314963657679543
 GameObject:
   m_ObjectHideFlags: 0
@@ -54348,6 +54506,139 @@ MonoBehaviour:
   serializedPublicVariablesBytesString: Ai8AAAAAATIAAABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlAFQAYQBiAGwAZQAsACAAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4AAAAAAAYBAAAAAAAAACcBBAAAAHQAeQBwAGUAAWgAAABTAHkAcwB0AGUAbQAuAEMAbwBsAGwAZQBjAHQAaQBvAG4AcwAuAEcAZQBuAGUAcgBpAGMALgBMAGkAcwB0AGAAMQBbAFsAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4ALgBJAG4AdABlAHIAZgBhAGMAZQBzAC4ASQBVAGQAbwBuAFYAYQByAGkAYQBiAGwAZQAsACAAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4AXQBdACwAIABtAHMAYwBvAHIAbABpAGIAAQEJAAAAVgBhAHIAaQBhAGIAbABlAHMALwEAAAABaAAAAFMAeQBzAHQAZQBtAC4AQwBvAGwAbABlAGMAdABpAG8AbgBzAC4ARwBlAG4AZQByAGkAYwAuAEwAaQBzAHQAYAAxAFsAWwBWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAEkAbgB0AGUAcgBmAGEAYwBlAHMALgBJAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlACwAIABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgBdAF0ALAAgAG0AcwBjAG8AcgBsAGkAYgABAAAABgEAAAAAAAAAAi8CAAAAAUkAAABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlAGAAMQBbAFsAUwB5AHMAdABlAG0ALgBJAG4AdAAzADIALAAgAG0AcwBjAG8AcgBsAGkAYgBdAF0ALAAgAFYAUgBDAC4AVQBkAG8AbgAuAEMAbwBtAG0AbwBuAAIAAAAGAgAAAAAAAAAnAQQAAAB0AHkAcABlAAEXAAAAUwB5AHMAdABlAG0ALgBTAHQAcgBpAG4AZwAsACAAbQBzAGMAbwByAGwAaQBiACcBCgAAAFMAeQBtAGIAbwBsAE4AYQBtAGUAAR8AAABfAF8AXwBVAGQAbwBuAFMAaABhAHIAcABCAGUAaABhAHYAaQBvAHUAcgBWAGUAcgBzAGkAbwBuAF8AXwBfACcBBAAAAHQAeQBwAGUAARYAAABTAHkAcwB0AGUAbQAuAEkAbgB0ADMAMgAsACAAbQBzAGMAbwByAGwAaQBiABcBBQAAAFYAYQBsAHUAZQACAAAABwUHBQcF
   publicVariablesUnityEngineObjects: []
   publicVariablesSerializationDataFormat: 0
+--- !u!1 &4957766028043664242
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1982190093183804386}
+  - component: {fileID: 1535440775908623280}
+  - component: {fileID: 3394730439282125995}
+  m_Layer: 0
+  m_Name: LABEL_SYMBOLS
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1982190093183804386
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4957766028043664242}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7499305319063945412}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -8, y: 16}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1535440775908623280
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4957766028043664242}
+  m_CullTransparentMesh: 0
+--- !u!114 &3394730439282125995
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4957766028043664242}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Selected Symbol Info
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4291611852
+  m_fontColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12.5
+  m_fontSizeBase: 12.5
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4967233361151248406
 GameObject:
   m_ObjectHideFlags: 0
@@ -55714,6 +56005,83 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 0
+--- !u!1 &5092411283119299079
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7499305319063945412}
+  - component: {fileID: 8988039378018359235}
+  - component: {fileID: 7890173186272509182}
+  m_Layer: 0
+  m_Name: HEADER_SYMBOL_EDIT
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7499305319063945412
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5092411283119299079}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3315783714719116490}
+  - {fileID: 2971927798548322818}
+  - {fileID: 1982190093183804386}
+  m_Father: {fileID: 8930267571219682672}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 60}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &8988039378018359235
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5092411283119299079}
+  m_CullTransparentMesh: 0
+--- !u!114 &7890173186272509182
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5092411283119299079}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2509804, g: 0.2509804, b: 0.2509804, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5130828974540918952
 GameObject:
   m_ObjectHideFlags: 0
@@ -65379,6 +65747,8 @@ RectTransform:
   m_Children:
   - {fileID: 6489242150008429694}
   - {fileID: 1176155634533447367}
+  - {fileID: 7499305319063945412}
+  - {fileID: 4709041438451282953}
   m_Father: {fileID: 4871742264126909826}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -66461,6 +66831,108 @@ MonoBehaviour:
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
+--- !u!1 &6299275439110405757
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4709041438451282953}
+  - component: {fileID: 1168240279626338165}
+  - component: {fileID: 3546611842009086335}
+  - component: {fileID: 6112193312558032743}
+  m_Layer: 0
+  m_Name: PANEL_SYMBOL_EDIT
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4709041438451282953
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6299275439110405757}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8490249798458228318}
+  - {fileID: 7606473682968368335}
+  m_Father: {fileID: 8930267571219682672}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &1168240279626338165
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6299275439110405757}
+  m_CullTransparentMesh: 0
+--- !u!114 &3546611842009086335
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6299275439110405757}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.21960784, g: 0.21960784, b: 0.21960784, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6112193312558032743
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6299275439110405757}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
 --- !u!1 &6301862308228877700
 GameObject:
   m_ObjectHideFlags: 0
@@ -97024,8 +97496,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -10}
-  m_SizeDelta: {x: 0, y: -20}
+  m_AnchoredPosition: {x: 0, y: 30}
+  m_SizeDelta: {x: 0, y: -100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5056972670816371062
 CanvasRenderer:
@@ -97718,3 +98190,309 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1001 &225579721022014621
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4709041438451282953}
+    m_Modifications:
+    - target: {fileID: 581821971583932668, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_Text
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014110166296962706, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_Name
+      value: FIELD_SYMBOL_TYPE
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390656965825602405, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_text
+      value: Type
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -30
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7733530533115775474, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: serializationData.Prefab
+      value: 
+      objectReference: {fileID: 7733530533115775474, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2dbcc61eec72e4f45b3fbc873d6510a2, type: 3}
+--- !u!224 &7606473682968368335 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+    type: 3}
+  m_PrefabInstance: {fileID: 225579721022014621}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7526199440941272431 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7733530533115775474, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+    type: 3}
+  m_PrefabInstance: {fileID: 225579721022014621}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78ee0beef995ce446bf57699bff939ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &2269138259333115404
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4709041438451282953}
+    m_Modifications:
+    - target: {fileID: 581821971583932668, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_Text
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 5014110166296962706, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_Name
+      value: FIELD_SYMBOL_NAME
+      objectReference: {fileID: 0}
+    - target: {fileID: 7390656965825602405, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_text
+      value: Name
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 300
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7733530533115775474, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+      propertyPath: serializationData.Prefab
+      value: 
+      objectReference: {fileID: 7733530533115775474, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+        type: 3}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2dbcc61eec72e4f45b3fbc873d6510a2, type: 3}
+--- !u!114 &8371800499309815806 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7733530533115775474, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+    type: 3}
+  m_PrefabInstance: {fileID: 2269138259333115404}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 78ee0beef995ce446bf57699bff939ce, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8490249798458228318 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7687349947127255122, guid: 2dbcc61eec72e4f45b3fbc873d6510a2,
+    type: 3}
+  m_PrefabInstance: {fileID: 2269138259333115404}
+  m_PrefabAsset: {fileID: 0}

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_System.Enum.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_System.Enum.prefab
@@ -832,9 +832,10 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 933579676773076179}
-  Interactive: 0
+  fieldLabel: {fileID: 7619138653168583286}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
+  fieldId: -1
   dropdown: {fileID: 2612097440331921311}
   label: {fileID: 4151898760570152201}
 --- !u!114 &933579676773076179
@@ -1356,6 +1357,18 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b, type: 3}
+--- !u!114 &7619138653168583286 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 8706788796826835}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &3724394679988017269 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3724859511904984230, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_SystemSingle.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_SystemSingle.prefab
@@ -148,9 +148,10 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 7129131623656746561}
-  Interactive: 0
+  fieldLabel: {fileID: 7390656965825602405}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
+  fieldId: -1
   inputField: {fileID: 3444757815928775100}
   slider: {fileID: 0}
 --- !u!114 &7129131623656746561
@@ -607,3 +608,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1095099983014421952}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7390656965825602405 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1095099983014421952}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_SystemSingle_Range.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_SystemSingle_Range.prefab
@@ -410,7 +410,7 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 656198630834663851}
-  fieldLabel: {fileID: 0}
+  fieldLabel: {fileID: 1694167059220698138}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
   fieldId: -1
@@ -906,3 +906,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 9088425733467263679}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1694167059220698138 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 9088425733467263679}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_SystemString.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_SystemString.prefab
@@ -148,9 +148,10 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 5675298312224469850}
-  Interactive: 0
+  fieldLabel: {fileID: 7390656965825602405}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
+  fieldId: -1
   inputField: {fileID: 3444757815928775100}
 --- !u!114 &5675298312224469850
 MonoBehaviour:
@@ -576,3 +577,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1095099983014421952}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7390656965825602405 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1095099983014421952}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngine.LayerMask.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngine.LayerMask.prefab
@@ -106,9 +106,10 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 171616274747783591}
-  Interactive: 0
+  fieldLabel: {fileID: 3804786838616344105}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
+  fieldId: -1
   backingDropdown: {fileID: 8732980558653567936}
   dropdown: {fileID: 2612832224937912702}
   label: {fileID: 7273118410486833494}
@@ -1427,6 +1428,18 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b, type: 3}
+--- !u!114 &3804786838616344105 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 6732636814737031308}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &7988957473762090026 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3724859511904984230, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineColor.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineColor.prefab
@@ -349,11 +349,15 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 3520249248457926944}
-  Interactive: 0
+  fieldLabel: {fileID: 7970240061960880597}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
+  fieldId: -1
   colorPreview: {fileID: 9143130771163774868}
   colorAlphaFill: {fileID: 5214074743152610398}
+  colorAlphaFillRectTransform: {fileID: 0}
+  hasAlpha: 0
+  isHDR: 0
 --- !u!114 &3520249248457926944
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -505,3 +509,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 520601027101411184}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7970240061960880597 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 520601027101411184}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineColorNoAlpha.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineColorNoAlpha.prefab
@@ -199,11 +199,15 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 3520249248457926944}
-  Interactive: 0
+  fieldLabel: {fileID: 7970240061960880597}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
+  fieldId: -1
   colorPreview: {fileID: 9143130771163774868}
   colorAlphaFill: {fileID: 0}
+  colorAlphaFillRectTransform: {fileID: 0}
+  hasAlpha: 0
+  isHDR: 0
 --- !u!114 &3520249248457926944
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -355,3 +359,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 520601027101411184}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7970240061960880597 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 520601027101411184}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineObject.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineObject.prefab
@@ -288,10 +288,12 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 5932905678837611461}
-  Interactive: 0
+  fieldLabel: {fileID: 8165232544023870989}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
+  fieldId: -1
   valueLabel: {fileID: 8783081342055483798}
+  FieldTypeNameOverride: 
   udonity: {fileID: 0}
 --- !u!114 &5932905678837611461
 MonoBehaviour:
@@ -802,3 +804,15 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1797722708265482408}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8165232544023870989 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1797722708265482408}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineVector2.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineVector2.prefab
@@ -727,9 +727,10 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 8050412139372910301}
-  Interactive: 0
+  fieldLabel: {fileID: 4768368341759178100}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
+  fieldId: -1
   inputFieldX: {fileID: 824855958875568045}
   inputFieldY: {fileID: 1638171938795341752}
 --- !u!114 &8050412139372910301
@@ -967,6 +968,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 3138680485758596049}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &4768368341759178100 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 3138680485758596049}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &3909975427656588467
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineVector3.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/UI Elements/Fields/FIELD_UnityEngineVector3.prefab
@@ -392,12 +392,15 @@ MonoBehaviour:
     PrefabModifications: []
     SerializationNodes: []
   _udonSharpBackingUdonBehaviour: {fileID: 2832819372932640821}
-  Interactive: 0
+  fieldLabel: {fileID: 867240107827342470}
   valueChangedCallbackReceiver: {fileID: 0}
   valueChangedCallbackMethod: 
+  fieldId: -1
   inputFieldX: {fileID: 4996693111882608223}
   inputFieldY: {fileID: 6385646068900290122}
   inputFieldZ: {fileID: 6176990247661539221}
+  constrainProportionsToggle: {fileID: 0}
+  ConstrainProportions: 0
 --- !u!114 &2832819372932640821
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1705,6 +1708,18 @@ PrefabInstance:
         type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b, type: 3}
+--- !u!114 &867240107827342470 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7611770545860855461, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,
+    type: 3}
+  m_PrefabInstance: {fileID: 7326088526310959651}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &6204312456387409541 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 3724859511904984230, guid: db8b077ae8e04ed4b9e2a6fe1e697f8b,

--- a/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/Windows/Udon Monitor/UDON_MONITOR_SYMBOL_LIST_ITEM.prefab
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Prefabs/UI/Windows/Udon Monitor/UDON_MONITOR_SYMBOL_LIST_ITEM.prefab
@@ -143,6 +143,8 @@ GameObject:
   m_Component:
   - component: {fileID: 4244946386604633914}
   - component: {fileID: 3404635334732154704}
+  - component: {fileID: 3637597436686545433}
+  - component: {fileID: 374517184106054309}
   - component: {fileID: 8613166890542069995}
   - component: {fileID: 7472420634250355314}
   m_Layer: 0
@@ -215,7 +217,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 374517184106054309}
         m_MethodName: SendCustomEvent
         m_Mode: 5
         m_Arguments:
@@ -223,9 +225,57 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: Select
+          m_StringArgument: SelectSymbol
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &3637597436686545433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6004917945910750663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db9d3fc6dcec30646bc23f786783671a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes: []
+  _udonSharpBackingUdonBehaviour: {fileID: 374517184106054309}
+--- !u!114 &374517184106054309
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6004917945910750663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45115577ef41a5b4ca741ed302693907, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  interactTextPlacement: {fileID: 0}
+  interactText: Use
+  interactTextGO: {fileID: 0}
+  proximity: 2
+  SynchronizePosition: 0
+  AllowCollisionOwnershipTransfer: 0
+  Reliable: 0
+  _syncMethod: 0
+  serializedProgramAsset: {fileID: 11400000, guid: 7bcec90adabca5c4ba7ac7f1a600da95,
+    type: 2}
+  programSource: {fileID: 11400000, guid: e6f1e5919205b3243b89fb1a12a50fa2, type: 2}
+  serializedPublicVariablesBytesString: Ai8AAAAAATIAAABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlAFQAYQBiAGwAZQAsACAAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4AAAAAAAYBAAAAAAAAACcBBAAAAHQAeQBwAGUAAWgAAABTAHkAcwB0AGUAbQAuAEMAbwBsAGwAZQBjAHQAaQBvAG4AcwAuAEcAZQBuAGUAcgBpAGMALgBMAGkAcwB0AGAAMQBbAFsAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4ALgBJAG4AdABlAHIAZgBhAGMAZQBzAC4ASQBVAGQAbwBuAFYAYQByAGkAYQBiAGwAZQAsACAAVgBSAEMALgBVAGQAbwBuAC4AQwBvAG0AbQBvAG4AXQBdACwAIABtAHMAYwBvAHIAbABpAGIAAQEJAAAAVgBhAHIAaQBhAGIAbABlAHMALwEAAAABaAAAAFMAeQBzAHQAZQBtAC4AQwBvAGwAbABlAGMAdABpAG8AbgBzAC4ARwBlAG4AZQByAGkAYwAuAEwAaQBzAHQAYAAxAFsAWwBWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAEkAbgB0AGUAcgBmAGEAYwBlAHMALgBJAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlACwAIABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgBdAF0ALAAgAG0AcwBjAG8AcgBsAGkAYgABAAAABgEAAAAAAAAAAi8CAAAAAUkAAABWAFIAQwAuAFUAZABvAG4ALgBDAG8AbQBtAG8AbgAuAFUAZABvAG4AVgBhAHIAaQBhAGIAbABlAGAAMQBbAFsAUwB5AHMAdABlAG0ALgBJAG4AdAAzADIALAAgAG0AcwBjAG8AcgBsAGkAYgBdAF0ALAAgAFYAUgBDAC4AVQBkAG8AbgAuAEMAbwBtAG0AbwBuAAIAAAAGAgAAAAAAAAAnAQQAAAB0AHkAcABlAAEXAAAAUwB5AHMAdABlAG0ALgBTAHQAcgBpAG4AZwAsACAAbQBzAGMAbwByAGwAaQBiACcBCgAAAFMAeQBtAGIAbwBsAE4AYQBtAGUAAR8AAABfAF8AXwBVAGQAbwBuAFMAaABhAHIAcABCAGUAaABhAHYAaQBvAHUAcgBWAGUAcgBzAGkAbwBuAF8AXwBfACcBBAAAAHQAeQBwAGUAARYAAABTAHkAcwB0AGUAbQAuAEkAbgB0ADMAMgAsACAAbQBzAGMAbwByAGwAaQBiABcBBQAAAFYAYQBsAHUAZQACAAAABwUHBQcF
+  publicVariablesUnityEngineObjects: []
+  publicVariablesSerializationDataFormat: 0
 --- !u!222 &8613166890542069995
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Abstract/Field.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Abstract/Field.cs
@@ -37,6 +37,11 @@ namespace Varneon.VUdon.Udonity.Fields.Abstract
         [SerializeField, HideInInspector]
         private int fieldId = -1;
 
+        public void SetLabelText(string text)
+        {
+            fieldLabel.text = text;
+        }
+
         public void RegisterValueChangedCallback(UdonSharpBehaviour callbackReceiver, string methodName)
         {
             valueChangedCallbackReceiver = callbackReceiver;

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Abstract/Field.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Abstract/Field.cs
@@ -1,4 +1,5 @@
-﻿using TMPro;
+﻿using System;
+using TMPro;
 using UdonSharp;
 using UnityEngine;
 
@@ -7,6 +8,10 @@ namespace Varneon.VUdon.Udonity.Fields.Abstract
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public abstract class Field : UdonSharpBehaviour
     {
+        public abstract object AbstractValue { get; }
+
+        public abstract Type FieldType { get; }
+
         public bool Interactive
         {
             get => interactive;
@@ -70,5 +75,7 @@ namespace Varneon.VUdon.Udonity.Fields.Abstract
         }
 
         protected virtual void OnInteractiveChanged(bool interactive) { }
+
+        public abstract bool TrySetAbstractValueWithoutNotify(object value);
     }
 }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/ColorField.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/ColorField.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿using System;
+using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,6 +10,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class ColorField : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(Color);
+
         public bool HasAlpha => hasAlpha;
 
         public bool IsHDR => isHDR;
@@ -81,6 +86,15 @@ namespace Varneon.VUdon.Udonity.Fields
         internal void EndColorEditing()
         {
             lockForDialogEditing = false;
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if(value == null || !value.GetType().Equals(FieldType)) { return false; }
+
+            SetValueWithoutNotify((Color)value);
+
+            return true;
         }
 
 #if !COMPILER_UDONSHARP

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/EnumField.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/EnumField.cs
@@ -1,4 +1,5 @@
-﻿using TMPro;
+﻿using System;
+using TMPro;
 using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
@@ -10,6 +11,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class EnumField : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(int);
+
         [SerializeField]
         private Dropdown dropdown;
 
@@ -32,6 +37,15 @@ namespace Varneon.VUdon.Udonity.Fields
         public void OnSubmit()
         {
             Value = dropdown.value;
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if (value == null || !value.GetType().Equals(FieldType)) { return false; }
+
+            SetValueWithoutNotify((int)value);
+
+            return true;
         }
     }
 }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/EnumFlagsField.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/EnumFlagsField.cs
@@ -1,4 +1,5 @@
-﻿using TMPro;
+﻿using System;
+using TMPro;
 using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
@@ -10,6 +11,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class EnumFlagsField : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(int);
+
         [SerializeField]
         private Dropdown dropdown;
 
@@ -107,6 +112,15 @@ namespace Varneon.VUdon.Udonity.Fields
                     Value |= mask;
                 }
             }
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if (value == null || !value.GetType().Equals(FieldType)) { return false; }
+
+            SetValueWithoutNotify((int)value);
+
+            return true;
         }
     }
 }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/FloatField.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/FloatField.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿using System;
+using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,6 +10,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class FloatField : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(float);
+
         [SerializeField]
         private InputField inputField;
 
@@ -69,6 +74,15 @@ namespace Varneon.VUdon.Udonity.Fields
         public void OnSliderUpdated()
         {
             Value = slider.value;
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if (value == null || !value.GetType().Equals(FieldType)) { return false; }
+
+            SetValueWithoutNotify((float)value);
+
+            return true;
         }
     }
 }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/LayerMaskField.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/LayerMaskField.cs
@@ -1,4 +1,5 @@
-﻿using TMPro;
+﻿using System;
+using TMPro;
 using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
@@ -10,6 +11,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class LayerMaskField : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(LayerMask);
+
         [SerializeField]
         private Dropdown backingDropdown;
 
@@ -35,6 +40,15 @@ namespace Varneon.VUdon.Udonity.Fields
         public void OnSubmit()
         {
             Value = dropdown.Value;
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if (value == null || (!value.GetType().Equals(FieldType) || !value.GetType().Equals(typeof(int)))) { return false; }
+
+            SetValueWithoutNotify((int)value);
+
+            return true;
         }
     }
 }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/ObjectField.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/ObjectField.cs
@@ -1,6 +1,8 @@
-﻿using TMPro;
+﻿using System;
+using TMPro;
 using UdonSharp;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Varneon.VUdon.Udonity.Fields
 {
@@ -9,6 +11,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class ObjectField : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(Object);
+
         [SerializeField]
         private TextMeshProUGUI valueLabel;
 
@@ -111,6 +117,15 @@ namespace Varneon.VUdon.Udonity.Fields
         internal void EndObjectDialogSelection()
         {
             lockForDialogEditing = false;
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if (value != null && !value.GetType().Equals(FieldType)) { return false; }
+
+            SetValueWithoutNotify((Object)value);
+
+            return true;
         }
 
 #if !COMPILER_UDONSHARP

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/TextField.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/TextField.cs
@@ -61,6 +61,11 @@ namespace Varneon.VUdon.Udonity.Fields
             inputField.OnDeselect(null);
         }
 
+        protected override void OnInteractiveChanged(bool interactive)
+        {
+            inputField.interactable = interactive;
+        }
+
         public override bool TrySetAbstractValueWithoutNotify(object value)
         {
             if (value != null && !value.GetType().Equals(FieldType)) { return false; }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/TextField.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/TextField.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿using System;
+using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,6 +10,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class TextField : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(string);
+
         [SerializeField]
         private InputField inputField;
 
@@ -54,6 +59,15 @@ namespace Varneon.VUdon.Udonity.Fields
             fieldLockedForEdit = false;
 
             inputField.OnDeselect(null);
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if (value != null && !value.GetType().Equals(FieldType)) { return false; }
+
+            SetValueWithoutNotify((string)value);
+
+            return true;
         }
     }
 }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Toggle.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Toggle.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿using System;
+using UdonSharp;
 using UnityEngine;
 
 namespace Varneon.VUdon.Udonity.Fields
@@ -8,6 +9,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class Toggle : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(bool);
+
         [SerializeField]
         private UnityEngine.UI.Toggle toggle;
 
@@ -30,6 +35,15 @@ namespace Varneon.VUdon.Udonity.Fields
         protected override void OnInteractiveChanged(bool interactive)
         {
             toggle.interactable = interactive;
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if (value == null || !value.GetType().Equals(FieldType)) { return false; }
+
+            SetValueWithoutNotify((bool)value);
+
+            return true;
         }
     }
 }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Vector2Field.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Vector2Field.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿using System;
+using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,6 +10,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class Vector2Field : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(Vector2);
+
         [SerializeField]
         private InputField inputFieldX, inputFieldY;
 
@@ -61,6 +66,15 @@ namespace Varneon.VUdon.Udonity.Fields
             }
 
             editingY = false;
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if (value == null || !value.GetType().Equals(FieldType)) { return false; }
+
+            SetValueWithoutNotify((Vector2)value);
+
+            return true;
         }
     }
 }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Vector3Field.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Fields/Vector3Field.cs
@@ -1,4 +1,5 @@
-﻿using UdonSharp;
+﻿using System;
+using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,6 +10,10 @@ namespace Varneon.VUdon.Udonity.Fields
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class Vector3Field : Abstract.Field
     {
+        public override object AbstractValue => _value;
+
+        public override Type FieldType => typeof(Vector3);
+
         [SerializeField]
         private InputField inputFieldX, inputFieldY, inputFieldZ;
 
@@ -122,6 +127,15 @@ namespace Varneon.VUdon.Udonity.Fields
         public void OnConstrainProportionsChanged()
         {
             ConstrainProportions = constrainProportionsToggle.isOn;
+        }
+
+        public override bool TrySetAbstractValueWithoutNotify(object value)
+        {
+            if (value == null || !value.GetType().Equals(FieldType)) { return false; }
+
+            SetValueWithoutNotify((Vector3)value);
+
+            return true;
         }
     }
 }

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Udonity.asset
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Udonity.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 26
+      Data: 29
     - Name: 
       Entry: 7
       Data: 
@@ -1271,19 +1271,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: colorFieldPrefab
+      Data: toggleFieldPrefab
     - Name: $v
       Entry: 7
       Data: 83|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: colorFieldPrefab
+      Data: toggleFieldPrefab
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 84|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: Varneon.VUdon.Udonity.Fields.ColorField, Varneon.VUdon.Udonity.Runtime
+      Data: Varneon.VUdon.Udonity.Fields.Toggle, Varneon.VUdon.Udonity.Runtime
     - Name: 
       Entry: 8
       Data: 
@@ -1331,19 +1331,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: vector3FieldPrefab
+      Data: textFieldPrefab
     - Name: $v
       Entry: 7
       Data: 87|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: vector3FieldPrefab
+      Data: textFieldPrefab
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 88|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: Varneon.VUdon.Udonity.Fields.Vector3Field, Varneon.VUdon.Udonity.Runtime
+      Data: Varneon.VUdon.Udonity.Fields.TextField, Varneon.VUdon.Udonity.Runtime
     - Name: 
       Entry: 8
       Data: 
@@ -1391,19 +1391,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: floatFieldPrefab
+      Data: colorFieldPrefab
     - Name: $v
       Entry: 7
       Data: 91|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: floatFieldPrefab
+      Data: colorFieldPrefab
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 92|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: Varneon.VUdon.Udonity.Fields.FloatField, Varneon.VUdon.Udonity.Runtime
+      Data: Varneon.VUdon.Udonity.Fields.ColorField, Varneon.VUdon.Udonity.Runtime
     - Name: 
       Entry: 8
       Data: 
@@ -1451,16 +1451,22 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: rangedFloatFieldPrefab
+      Data: vector2FieldPrefab
     - Name: $v
       Entry: 7
       Data: 95|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: rangedFloatFieldPrefab
+      Data: vector2FieldPrefab
     - Name: <UserType>k__BackingField
-      Entry: 9
-      Data: 92
+      Entry: 7
+      Data: 96|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Varneon.VUdon.Udonity.Fields.Vector2Field, Varneon.VUdon.Udonity.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
       Data: 7
@@ -1478,13 +1484,190 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 96|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 97|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 97|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 98|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: vector3FieldPrefab
+    - Name: $v
+      Entry: 7
+      Data: 99|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: vector3FieldPrefab
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 100|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Varneon.VUdon.Udonity.Fields.Vector3Field, Varneon.VUdon.Udonity.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 7
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 101|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 102|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: floatFieldPrefab
+    - Name: $v
+      Entry: 7
+      Data: 103|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: floatFieldPrefab
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 104|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Varneon.VUdon.Udonity.Fields.FloatField, Varneon.VUdon.Udonity.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 7
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 105|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 106|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: rangedFloatFieldPrefab
+    - Name: $v
+      Entry: 7
+      Data: 107|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: rangedFloatFieldPrefab
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 104
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 7
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 108|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+        mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 109|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -1508,13 +1691,13 @@ MonoBehaviour:
       Data: objectFieldPrefab
     - Name: $v
       Entry: 7
-      Data: 98|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 110|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: objectFieldPrefab
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 99|System.RuntimeType, mscorlib
+      Data: 111|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: Varneon.VUdon.Udonity.Fields.ObjectField, Varneon.VUdon.Udonity.Runtime
@@ -1538,14 +1721,14 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 100|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 112|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 101|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 113|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -1569,13 +1752,13 @@ MonoBehaviour:
       Data: draggedObject
     - Name: $v
       Entry: 7
-      Data: 102|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 114|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: draggedObject
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 103|System.RuntimeType, mscorlib
+      Data: 115|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.GameObject, UnityEngine.CoreModule
@@ -1584,7 +1767,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 103
+      Data: 115
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -1599,7 +1782,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 104|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
+      Data: 116|System.Collections.Generic.List`1[[System.Attribute, mscorlib]],
         mscorlib
     - Name: 
       Entry: 12

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Udonity.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Udonity.cs
@@ -44,7 +44,13 @@ namespace Varneon.VUdon.Udonity
 
         public MeshColliderVisualizer MeshColliderVisualizerPrefab => meshColliderVisualizerPrefab;
 
+        public Toggle ToggleFieldPrefab => toggleFieldPrefab;
+
+        public TextField TextFieldPrefab => textFieldPrefab;
+
         public ColorField ColorFieldPrefab => colorFieldPrefab;
+
+        public Vector2Field Vector2FieldPrefab => vector2FieldPrefab;
 
         public Vector3Field Vector3FieldPrefab => vector3FieldPrefab;
 
@@ -119,7 +125,16 @@ namespace Varneon.VUdon.Udonity
         private MeshColliderVisualizer meshColliderVisualizerPrefab;
 
         [SerializeField]
+        private Toggle toggleFieldPrefab;
+
+        [SerializeField]
+        private TextField textFieldPrefab;
+
+        [SerializeField]
         private ColorField colorFieldPrefab;
+
+        [SerializeField]
+        private Vector2Field vector2FieldPrefab;
 
         [SerializeField]
         private Vector3Field vector3FieldPrefab;
@@ -262,7 +277,10 @@ namespace Varneon.VUdon.Udonity
 
             boxColliderVisualizerPrefab = Instantiate(boxColliderVisualizerPrefab, runtimePrefabParent);
             meshColliderVisualizerPrefab = Instantiate(meshColliderVisualizerPrefab, runtimePrefabParent);
+            toggleFieldPrefab = Instantiate(toggleFieldPrefab, runtimePrefabParent);
+            textFieldPrefab = Instantiate(textFieldPrefab, runtimePrefabParent);
             colorFieldPrefab = Instantiate(colorFieldPrefab, runtimePrefabParent);
+            vector2FieldPrefab = Instantiate(vector2FieldPrefab, runtimePrefabParent);
             vector3FieldPrefab = Instantiate(vector3FieldPrefab, runtimePrefabParent);
             floatFieldPrefab = Instantiate(floatFieldPrefab, runtimePrefabParent);
             rangedFloatFieldPrefab = Instantiate(rangedFloatFieldPrefab, runtimePrefabParent);

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/Udon Monitor/UdonMonitorSymbolElement.asset
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/Udon Monitor/UdonMonitorSymbolElement.asset
@@ -1,0 +1,161 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
+  m_Name: UdonMonitorSymbolElement
+  m_EditorClassIdentifier: 
+  serializedUdonProgramAsset: {fileID: 11400000, guid: 7bcec90adabca5c4ba7ac7f1a600da95,
+    type: 2}
+  udonAssembly: 
+  assemblyError: 
+  sourceCsScript: {fileID: 11500000, guid: db9d3fc6dcec30646bc23f786783671a, type: 3}
+  scriptVersion: 2
+  compiledVersion: 2
+  behaviourSyncMode: 1
+  hasInteractEvent: 0
+  scriptID: -5253196559406706798
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: fieldDefinitions
+      Entry: 7
+      Data: 0|System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[UdonSharp.Compiler.FieldDefinition,
+        UdonSharp.Editor]], mscorlib
+    - Name: comparer
+      Entry: 7
+      Data: 1|System.Collections.Generic.GenericEqualityComparer`1[[System.String,
+        mscorlib]], mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 12
+      Data: 2
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: symbolType
+    - Name: $v
+      Entry: 7
+      Data: 2|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: symbolType
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 3|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Type, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 3
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 4|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: symbolName
+    - Name: $v
+      Entry: 7
+      Data: 5|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: symbolName
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 6|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.String, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 6
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 7|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/Udon Monitor/UdonMonitorSymbolElement.asset.meta
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/Udon Monitor/UdonMonitorSymbolElement.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e6f1e5919205b3243b89fb1a12a50fa2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/Udon Monitor/UdonMonitorSymbolElement.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/Udon Monitor/UdonMonitorSymbolElement.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using UdonSharp;
+using UnityEngine;
+
+namespace Varneon.VUdon.Udonity.Windows.UdonMonitor
+{
+    [AddComponentMenu("")]
+    [DisallowMultipleComponent]
+    [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+    public class UdonMonitorSymbolElement : UdonSharpBehaviour
+    {
+        private Type symbolType;
+
+        private string symbolName;
+
+        internal void Initialize(string symbolName, Type symbolType)
+        {
+            this.symbolName = symbolName;
+            this.symbolType = symbolType;
+        }
+
+        public void SelectSymbol()
+        {
+            GetComponentInParent<UdonMonitorWindow>().SelectSymbol(symbolName, symbolType);
+        }
+    }
+}

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/Udon Monitor/UdonMonitorSymbolElement.cs.meta
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/Udon Monitor/UdonMonitorSymbolElement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db9d3fc6dcec30646bc23f786783671a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/UdonMonitorWindow.asset
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/UdonMonitorWindow.asset
@@ -44,7 +44,7 @@ MonoBehaviour:
       Data: 
     - Name: 
       Entry: 12
-      Data: 9
+      Data: 16
     - Name: 
       Entry: 7
       Data: 
@@ -122,25 +122,25 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: headerInfoText
+      Data: udonity
     - Name: $v
       Entry: 7
       Data: 8|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: headerInfoText
+      Data: udonity
     - Name: <UserType>k__BackingField
       Entry: 7
       Data: 9|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: TMPro.TextMeshProUGUI, Unity.TextMeshPro
+      Data: Varneon.VUdon.Udonity.Udonity, Varneon.VUdon.Udonity.Runtime
     - Name: 
       Entry: 8
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 9
+      Data: 4
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -158,10 +158,76 @@ MonoBehaviour:
       Data: 10|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 1
+      Data: 2
     - Name: 
       Entry: 7
       Data: 11|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 12|UnityEngine.HideInInspector, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: headerInfoText
+    - Name: $v
+      Entry: 7
+      Data: 13|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: headerInfoText
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 14|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: TMPro.TextMeshProUGUI, Unity.TextMeshPro
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 14
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 15|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 16|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -185,13 +251,13 @@ MonoBehaviour:
       Data: symbolContainer
     - Name: $v
       Entry: 7
-      Data: 12|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 17|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: symbolContainer
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 13|System.RuntimeType, mscorlib
+      Data: 18|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.RectTransform, UnityEngine.CoreModule
@@ -200,7 +266,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 13
+      Data: 18
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -215,13 +281,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 14|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 19|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 15|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 20|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -242,19 +308,19 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: entryPointContainer
+      Data: symbolFieldContainer
     - Name: $v
       Entry: 7
-      Data: 16|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 21|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
-      Data: entryPointContainer
+      Data: symbolFieldContainer
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 13
+      Data: 18
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 13
+      Data: 18
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -269,13 +335,67 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 17|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 22|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 18|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 23|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: entryPointContainer
+    - Name: $v
+      Entry: 7
+      Data: 24|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: entryPointContainer
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 18
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 25|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 26|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -299,13 +419,13 @@ MonoBehaviour:
       Data: symbolListItem
     - Name: $v
       Entry: 7
-      Data: 19|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 27|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: symbolListItem
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 20|System.RuntimeType, mscorlib
+      Data: 28|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: UnityEngine.GameObject, UnityEngine.CoreModule
@@ -314,7 +434,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 20
+      Data: 28
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -329,13 +449,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 21|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 29|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 22|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 30|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -359,16 +479,16 @@ MonoBehaviour:
       Data: entryPointListItem
     - Name: $v
       Entry: 7
-      Data: 23|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 31|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: entryPointListItem
     - Name: <UserType>k__BackingField
       Entry: 9
-      Data: 20
+      Data: 28
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 20
+      Data: 28
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -383,13 +503,127 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 24|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 25|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 33|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: symbolNameField
+    - Name: $v
+      Entry: 7
+      Data: 34|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: symbolNameField
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 35|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Varneon.VUdon.Udonity.Fields.TextField, Varneon.VUdon.Udonity.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 4
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 36|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 37|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: symbolTypeField
+    - Name: $v
+      Entry: 7
+      Data: 38|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: symbolTypeField
+    - Name: <UserType>k__BackingField
+      Entry: 9
+      Data: 35
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 4
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: true
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 39|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 40|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -413,13 +647,13 @@ MonoBehaviour:
       Data: logger
     - Name: $v
       Entry: 7
-      Data: 26|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 41|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: logger
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 27|System.RuntimeType, mscorlib
+      Data: 42|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: Varneon.VUdon.Logger.Abstract.UdonLogger, Varneon.VUdon.Logger.Runtime
@@ -443,13 +677,13 @@ MonoBehaviour:
       Data: true
     - Name: _fieldAttributes
       Entry: 7
-      Data: 28|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 43|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 29|UnityEngine.SerializeField, UnityEngine.CoreModule
+      Data: 44|UnityEngine.SerializeField, UnityEngine.CoreModule
     - Name: 
       Entry: 8
       Data: 
@@ -473,13 +707,13 @@ MonoBehaviour:
       Data: symbolCount
     - Name: $v
       Entry: 7
-      Data: 30|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 45|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: symbolCount
     - Name: <UserType>k__BackingField
       Entry: 7
-      Data: 31|System.RuntimeType, mscorlib
+      Data: 46|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.Int32, mscorlib
@@ -488,7 +722,7 @@ MonoBehaviour:
       Data: 
     - Name: <SystemType>k__BackingField
       Entry: 9
-      Data: 31
+      Data: 46
     - Name: <SyncMode>k__BackingField
       Entry: 7
       Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
@@ -503,7 +737,7 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 47|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -527,7 +761,7 @@ MonoBehaviour:
       Data: target
     - Name: $v
       Entry: 7
-      Data: 33|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 48|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: <Name>k__BackingField
       Entry: 1
       Data: target
@@ -551,7 +785,169 @@ MonoBehaviour:
       Data: false
     - Name: _fieldAttributes
       Entry: 7
-      Data: 34|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 49|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: typesAvailableForEdit
+    - Name: $v
+      Entry: 7
+      Data: 50|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: typesAvailableForEdit
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 51|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.Type[], mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 51
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 52|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: selectedSymbolName
+    - Name: $v
+      Entry: 7
+      Data: 53|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: selectedSymbolName
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 54|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: System.String, mscorlib
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 54
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 55|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: symbolField
+    - Name: $v
+      Entry: 7
+      Data: 56|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: <Name>k__BackingField
+      Entry: 1
+      Data: symbolField
+    - Name: <UserType>k__BackingField
+      Entry: 7
+      Data: 57|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: Varneon.VUdon.Udonity.Fields.Abstract.Field, Varneon.VUdon.Udonity.Runtime
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <SystemType>k__BackingField
+      Entry: 9
+      Data: 4
+    - Name: <SyncMode>k__BackingField
+      Entry: 7
+      Data: System.Nullable`1[[UdonSharp.UdonSyncMode, UdonSharp.Runtime]], mscorlib
+    - Name: 
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: <IsSerialized>k__BackingField
+      Entry: 5
+      Data: false
+    - Name: _fieldAttributes
+      Entry: 7
+      Data: 58|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/UdonMonitorWindow.cs
+++ b/Packages/com.varneon.vudon.udonity/Runtime/Udon Programs/Windows/UdonMonitorWindow.cs
@@ -6,6 +6,8 @@ using Varneon.VUdon.Udonity.Windows.Abstract;
 using VRC.Udon;
 using Varneon.VUdon.ArrayExtensions;
 using Varneon.VUdon.Logger.Abstract;
+using Varneon.VUdon.Udonity.Fields.Abstract;
+using Varneon.VUdon.Udonity.Fields;
 
 namespace Varneon.VUdon.Udonity.Windows.UdonMonitor
 {
@@ -19,11 +21,17 @@ namespace Varneon.VUdon.Udonity.Windows.UdonMonitor
         [SerializeField, HideInInspector]
         internal UdonProgramDataStorage programDataStorage;
 
+        [SerializeField, HideInInspector]
+        internal Udonity udonity;
+
         [SerializeField]
         private TextMeshProUGUI headerInfoText;
 
         [SerializeField]
         private RectTransform symbolContainer;
+
+        [SerializeField]
+        private RectTransform symbolFieldContainer;
 
         [SerializeField]
         private RectTransform entryPointContainer;
@@ -35,6 +43,12 @@ namespace Varneon.VUdon.Udonity.Windows.UdonMonitor
         private GameObject entryPointListItem;
 
         [SerializeField]
+        private TextField symbolNameField;
+
+        [SerializeField]
+        private TextField symbolTypeField;
+
+        [SerializeField]
         private UdonLogger logger;
 
         private int symbolCount;
@@ -42,6 +56,21 @@ namespace Varneon.VUdon.Udonity.Windows.UdonMonitor
         private UdonBehaviour target;
 
         private const string LOG_PREFIX = "[<color=#ABCDEF>UdonMonitor</color>]: ";
+
+        private readonly Type[] typesAvailableForEdit = new Type[]
+        {
+            typeof(bool),
+            typeof(int),
+            typeof(float),
+            typeof(string),
+            typeof(Vector2),
+            typeof(Vector3),
+            typeof(Color)
+        };
+
+        private string selectedSymbolName;
+
+        private Field symbolField;
 
         internal void OpenUdonBehaviour(UdonBehaviour udonBehaviour)
         {
@@ -70,7 +99,13 @@ namespace Varneon.VUdon.Udonity.Windows.UdonMonitor
             {
                 GameObject newSymbolListElement = Instantiate(symbolListItem, symbolContainer, false);
 
-                newSymbolListElement.GetComponentInChildren<TextMeshProUGUI>().text = $"<color=#abc>({symbolTypes[i].Name})</color> {symbols[i]}";
+                string symbolName = symbols[i];
+
+                Type symbolType = symbolTypes[i];
+
+                newSymbolListElement.GetComponentInChildren<TextMeshProUGUI>().text = $"<color=#abc>({symbolType.Name})</color> {symbols[i]}";
+
+                newSymbolListElement.GetComponent<UdonMonitorSymbolElement>().Initialize(symbolName, symbolType);
             }
 
             for(int i = 0; i < entryPoints.Length; i++)
@@ -90,8 +125,97 @@ namespace Varneon.VUdon.Udonity.Windows.UdonMonitor
             target.SendCustomEvent(methodName);
         }
 
+        internal void SelectSymbol(string symbolName, Type symbolType)
+        {
+            ClearSymbolEditField();
+
+            int typeIndex = typesAvailableForEdit.IndexOf(symbolType);
+
+            if(typeIndex < 0)
+            {
+                LogWarning(string.Concat("Editing of symbols of type <color=red>'", symbolType.FullName,"'</color> is not supported at this time."));
+            }
+
+            GameObject newFieldObject;
+
+            bool isReadonlyField = false;
+
+            string symbolTypeName = symbolType.Name;
+
+            switch (symbolTypeName)
+            {
+                case "Boolean":
+                    newFieldObject = Instantiate(udonity.ToggleFieldPrefab.gameObject, symbolFieldContainer);
+                    break;
+                case "Int32":
+                case "Single":
+                    newFieldObject = Instantiate(udonity.FloatFieldPrefab.gameObject, symbolFieldContainer);
+                    break;
+                case "String":
+                    newFieldObject = Instantiate(udonity.TextFieldPrefab.gameObject, symbolFieldContainer);
+                    break;
+                case "Vector2":
+                    newFieldObject = Instantiate(udonity.Vector2FieldPrefab.gameObject, symbolFieldContainer);
+                    break;
+                case "Vector3":
+                    newFieldObject = Instantiate(udonity.Vector3FieldPrefab.gameObject, symbolFieldContainer);
+                    break;
+                case "Color":
+                    newFieldObject = Instantiate(udonity.ColorFieldPrefab.gameObject, symbolFieldContainer);
+                    break;
+                default:
+                    newFieldObject = Instantiate(udonity.TextFieldPrefab.gameObject, symbolFieldContainer);
+                    isReadonlyField = true;
+                    break;
+            }
+
+            selectedSymbolName = symbolName;
+
+            symbolNameField.SetValueWithoutNotify(symbolName);
+
+            symbolTypeField.SetValueWithoutNotify(symbolTypeName);
+
+            symbolField = newFieldObject.GetComponent<Field>();
+
+            symbolField.SetLabelText(isReadonlyField ? "Value (Read-Only)" : "Value");
+
+            if (isReadonlyField)
+            {
+                object symbolValue = target.GetProgramVariable(symbolName);
+
+                ((TextField)symbolField).SetValueWithoutNotify(symbolValue == null ? "null" : symbolValue.ToString());
+
+                symbolField.Interactive = false;
+            }
+            else
+            {
+                symbolField.RegisterValueChangedCallback(this, nameof(OnSymbolValueChanged));
+
+                symbolField.TrySetAbstractValueWithoutNotify(target.GetProgramVariable(symbolName));
+            }
+        }
+
+        public void OnSymbolValueChanged()
+        {
+            target.SetProgramVariable(selectedSymbolName, symbolField.AbstractValue);
+        }
+
+        private void ClearSymbolEditField()
+        {
+            symbolNameField.SetValueWithoutNotify(string.Empty);
+
+            symbolTypeField.SetValueWithoutNotify(string.Empty);
+
+            if (symbolField)
+            {
+                Destroy(symbolField.gameObject);
+            }
+        }
+
         private void Clear()
         {
+            ClearSymbolEditField();
+
             headerInfoText.text = string.Empty;
 
             for(int i = 0; i < symbolContainer.childCount; i++)
@@ -112,5 +236,13 @@ namespace Varneon.VUdon.Udonity.Windows.UdonMonitor
                 logger.LogWarning(string.Concat(LOG_PREFIX, message));
             }
         }
+
+#if UNITY_EDITOR && !COMPILER_UDONSHARP
+        internal void InitializeOnBuild()
+        {
+            symbolNameField.Interactive = false;
+            symbolTypeField.Interactive = false;
+        }
+#endif
     }
 }


### PR DESCRIPTION
Fixes #48 

Following symbol types can be edited at this time:
- Boolean
- Int32
- Single
- String
- Vector2
- Vector3
- Color

More supported types will be added in the future.