### PR TITLE
Improve editor descriptor scale warning detection

### DIFF
--- a/Packages/com.varneon.vudon.udonity/CHANGELOG.md
+++ b/Packages/com.varneon.vudon.udonity/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes
 
 Fixed
 * Searching objects via hierarchy search field will return the root of the hierarchy instead of the child object, which wouldn't show up if the root didn't exist in the hierarchy yet
+* Editor descriptor scale detection now warns the user properly about scaled hierarchies
 
 [0.1.0-pre-alpha.8] - 2024-03-04
 Added

--- a/Packages/com.varneon.vudon.udonity/Editor/UdonityEditorDescriptorEditor.cs
+++ b/Packages/com.varneon.vudon.udonity/Editor/UdonityEditorDescriptorEditor.cs
@@ -119,21 +119,26 @@ namespace Varneon.VUdon.Udonity.Editor
         {
             GUILayout.Space(18);
 
-            if (editorDescriptor.transform.localScale != Vector3.one)
+            Vector3 lossyScale = editorDescriptor.transform.lossyScale;
+
+            if (lossyScale != Vector3.one)
             {
                 EditorGUILayout.HelpBox("Do not change the editor descriptor transform's scale!\n\nIf you want to scale the entire editor window, use the 'Canvas Scale' option in 'Window Settings' panel below.", MessageType.Error);
 
                 if (GUILayout.Button("Apply Descriptor Scale To Canvas"))
                 {
-                    Undo.RecordObjects(new Object[] { editorDescriptor.transform, canvasRectTransform }, "Fix Editor Scale");
+                    Transform[] transforms = editorDescriptor.transform.GetComponentsInParent<Transform>();
 
-                    Vector3 localScale = editorDescriptor.transform.localScale;
+                    Undo.RecordObjects(transforms.Select(t => (Object)t).Append(canvasRectTransform).ToArray(), "Fix Editor Scale");
 
-                    float transformScale = (localScale.x + localScale.y + localScale.z) / 3f;
+                    foreach(Transform t in transforms)
+                    {
+                        t.localScale = Vector3.one;
+                    }
+
+                    float transformScale = (lossyScale.x + lossyScale.y) / 2f;
 
                     float finalCanvasScale = canvasRectTransform.localScale.x * transformScale;
-
-                    editorDescriptor.transform.localScale = Vector3.one;
 
                     canvasRectTransform.localScale = Vector3.one * finalCanvasScale;
                 }


### PR DESCRIPTION
Fixes #63

- Editor descriptor scale warning now detects lossy scale instead of local scale
- Z-axis scale is now ignored in the scale apply since it doesn't visually affect the representation of the editor canvas